### PR TITLE
Add github new issue to CSP form-action

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -82,7 +82,7 @@
   }
 
   header @notimageproxy {
-        Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
+        Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
   }
 
   # SearXNG


### PR DESCRIPTION
Under current CSP header, when stats page is enabled, users can see "Submit a new issue on Github including the above information" button but cannot click on it, because it is blocked by CSP form-action policy. An example is [this instance](https://searx.loafland.xyz/stats?engine=google).

This PR fixes this issue by adding `https://github.com/searxng/searxng/issues/new` to form-action, making that button really work.