### PR TITLE
Restart the services automatically.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
   caddy:
     container_name: caddy
     image: caddy:2-alpine
+    restart: always
     network_mode: host
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
@@ -22,6 +23,7 @@ services:
   redis:
     container_name: redis
     image: "redis:alpine"
+    restart: always
     command: redis-server --save "" --appendonly "no"
     networks:
       - searxng
@@ -37,6 +39,7 @@ services:
   searxng:
     container_name: searxng
     image: searxng/searxng:latest
+    restart: always
     networks:
       - searxng
     ports:


### PR DESCRIPTION
Added option "restart: always" for caddy, redis and searxng service to restart and run always. searx-docker is also following the similar approach https://github.com/searx/searx-docker/blob/master/docker-compose.yaml