### PR TITLE
Update Caddyfile to Add X-Real-IP to fix bot detection

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -92,6 +92,7 @@
         reverse_proxy localhost:8080 {
                header_up X-Forwarded-Port {http.request.port}
                header_up X-Forwarded-Proto {http.request.scheme}
+               header_up X-Real-IP {remote_host}
         }
   }
 


### PR DESCRIPTION
Bot detection complains about not having X-Real-IP which is required https://docs.searxng.org/src/searx.botdetection.html#id4 this adds the header and fixes the problem for me.