### PR TITLE
Replace Redis with Valkey + reduce logging for containers caddy and redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Create a new SearXNG instance in five minutes using Docker
 
 ## What is included ?
 
-| Name                                          | Description                                                    | Docker image                                                                 | Dockerfile                                                                                      |
-|-----------------------------------------------|----------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| [Caddy](https://github.com/caddyserver/caddy) | Reverse proxy (create a LetsEncrypt certificate automatically) | [docker.io/library/caddy:2-alpine](https://hub.docker.com/_/caddy)           | [Dockerfile](https://raw.githubusercontent.com/caddyserver/caddy-docker/master/Dockerfile.tmpl) |
-| [SearXNG](https://github.com/searxng/searxng) | SearXNG by itself                                              | [docker.io/searxng/searxng:latest](https://hub.docker.com/r/searxng/searxng) | [Dockerfile](https://raw.githubusercontent.com/searxng/searxng/master/Dockerfile)               |
+| Name | Description | Docker image | Dockerfile |
+| -- | -- | -- | -- |
+| [Caddy](https://github.com/caddyserver/caddy) | Reverse proxy (create a LetsEncrypt certificate automatically) | [docker.io/library/caddy:2-alpine](https://hub.docker.com/_/caddy)           | [Dockerfile](https://github.com/caddyserver/caddy-docker/blob/master/Dockerfile.tmpl) |
+| [SearXNG](https://github.com/searxng/searxng) | SearXNG by itself                                              | [docker.io/searxng/searxng:latest](https://hub.docker.com/r/searxng/searxng) | [Dockerfile](https://github.com/searxng/searxng/blob/master/Dockerfile)               |
 | [Valkey](https://github.com/valkey-io/valkey) | In-memory database                                             | [cgr.dev/chainguard/valkey:latest](https://cgr.dev/chainguard/valkey)        | [Valkey-image](https://github.com/chainguard-images/images/tree/main/images/valkey)             |
 
 ## How to use it
@@ -24,6 +24,12 @@ Create a new SearXNG instance in five minutes using Docker
 - Edit the [searxng/settings.yml](https://github.com/searxng/searxng-docker/blob/master/searxng/settings.yml) file according to your need
 - Check everything is working: `docker compose up`
 - Run SearXNG in the background: `docker compose up -d`
+
+> [!WARNING]  
+> If you use an older version of docker desktop (`< 3.6.0`), you may have to install Docker Compose v1.
+> Accordingly, you should modify the commands in this documentation to suit Docker Compose v1. For instance, change 'docker compose up' to 'docker-compose up'.
+>
+> [Install the docker-compose plugin](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin) (be sure that docker-compose version is at least 1.9.0)
 
 ## How to access the logs
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # searxng-docker
 
-Create a new SearXNG  instance in five minutes using Docker
+Create a new SearXNG instance in five minutes using Docker
 
 ## What is included ?
 
-| Name | Description | Docker image | Dockerfile |
-| -- | -- | -- | -- |
-| [Caddy](https://github.com/caddyserver/caddy) | Reverse proxy (create a LetsEncrypt certificate automatically) | [caddy/caddy:2-alpine](https://hub.docker.com/_/caddy) | [Dockerfile](https://github.com/caddyserver/caddy-docker) |
-| [SearXNG](https://github.com/searxng/searxng) | SearXNG by itself | [searxng/searxng:latest](https://hub.docker.com/r/searxng/searxng) | [Dockerfile](https://github.com/searxng/searxng/blob/master/Dockerfile) |
-| [Redis](https://github.com/redis/redis) | In-memory database | [redis:alpine](https://hub.docker.com/_/redis) | [Dockerfile-alpine.template](https://github.com/docker-library/redis/blob/master/Dockerfile-alpine.template) |
+| Name                                          | Description                                                    | Docker image                                                                 | Dockerfile                                                                                      |
+|-----------------------------------------------|----------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| [Caddy](https://github.com/caddyserver/caddy) | Reverse proxy (create a LetsEncrypt certificate automatically) | [docker.io/library/caddy:2-alpine](https://hub.docker.com/_/caddy)           | [Dockerfile](https://raw.githubusercontent.com/caddyserver/caddy-docker/master/Dockerfile.tmpl) |
+| [SearXNG](https://github.com/searxng/searxng) | SearXNG by itself                                              | [docker.io/searxng/searxng:latest](https://hub.docker.com/r/searxng/searxng) | [Dockerfile](https://raw.githubusercontent.com/searxng/searxng/master/Dockerfile)               |
+| [Valkey](https://github.com/valkey-io/valkey) | In-memory database                                             | [cgr.dev/chainguard/valkey:latest](https://cgr.dev/chainguard/valkey)        | [Valkey-image](https://github.com/chainguard-images/images/tree/main/images/valkey)             |
 
 ## How to use it
+
 - [Install docker](https://docs.docker.com/install/)
 - Get searxng-docker
   ```sh
@@ -24,19 +25,15 @@ Create a new SearXNG  instance in five minutes using Docker
 - Check everything is working: `docker compose up`
 - Run SearXNG in the background: `docker compose up -d`
 
-> [!WARNING]  
-> If you use an older version of docker desktop (`< 3.6.0`), you may have to install Docker Compose v1.
-> Accordingly, you should modify the commands in this documentation to suit Docker Compose v1. For instance, change 'docker compose up' to 'docker-compose up'.
->
-> [Install the docker-compose plugin](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin) (be sure that docker-compose version is at least 1.9.0)
-
 ## How to access the logs
+
 To access the logs from all the containers use: `docker compose logs -f`.
 
 To access the logs of one specific container:
+
 - Caddy: `docker compose logs -f caddy`
 - SearXNG: `docker compose logs -f searxng`
-- Redis: `docker compose logs -f redis`
+- Valkey: `docker compose logs -f redis`
 
 ### Start SearXNG with systemd
 
@@ -56,11 +53,12 @@ The SearXNG image proxy is activated by default.
 
 The default [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) allow the browser to access to ```${SEARXNG_HOSTNAME}``` and ```https://*.tile.openstreetmap.org;```.
 
-If some users wants to disable the image proxy, you have to modify [./Caddyfile](https://github.com/searxng/searxng-docker/blob/master/Caddyfile). Replace the ```img-src 'self' data: https://*.tile.openstreetmap.org;``` by ```img-src * data:;```.
+If some users want to disable the image proxy, you have to modify [./Caddyfile](https://github.com/searxng/searxng-docker/blob/master/Caddyfile). Replace the ```img-src 'self' data: https://*.tile.openstreetmap.org;``` by ```img-src * data:;```.
 
 ## Multi Architecture Docker images
 
 Supported architecture:
+
 - amd64
 - arm64
 - arm/v7
@@ -76,6 +74,7 @@ docker compose up -d
 ```
 
 Or the old way (with the old docker-compose version):
+
 ```sh
 git pull
 docker-compose pull

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,21 +17,6 @@ services:
     cap_add:
       - NET_BIND_SERVICE
 
-  redis:
-    container_name: redis
-    image: docker.io/library/redis:alpine
-    command: redis-server --save 30 1 --loglevel warning
-    networks:
-      - searxng
-    volumes:
-      - redis-data:/data
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETGID
-      - SETUID
-      - DAC_OVERRIDE
-
   searxng:
     container_name: searxng
     image: docker.io/searxng/searxng:latest
@@ -55,6 +40,17 @@ services:
         max-size: "1m"
         max-file: "1"
 
+  valkey:
+    container_name: valkey
+    image: cgr.dev/chainguard/valkey:latest
+    command: valkey-server --save 30 1
+    networks:
+      - searxng
+    volumes:
+      - valkey-data:/data
+    security_opt:
+      - no-new-privileges:true
+
 networks:
   searxng:
     ipam:
@@ -63,4 +59,4 @@ networks:
 volumes:
   caddy-data:
   caddy-config:
-  redis-data:
+  valkey-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,11 +40,12 @@ services:
   valkey:
     container_name: valkey
     image: cgr.dev/chainguard/valkey:latest
-    command: valkey-server --save 30 1
+    command: --save 30 1
+    user: 0:0
     networks:
       - searxng
     volumes:
-      - valkey-data:/data
+      - redis-data:/data
     security_opt:
       - no-new-privileges:true
     logging:
@@ -59,4 +60,4 @@ networks:
 volumes:
   caddy-data:
   caddy-config:
-  valkey-data:
+  redis-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
     networks:
       - searxng
     volumes:
-      - redis-data:/data
+      - valkey-data:/data
     security_opt:
       - no-new-privileges:true
     logging:
@@ -59,4 +59,4 @@ networks:
 volumes:
   caddy-data:
   caddy-config:
-  redis-data:
+  valkey-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,12 +25,11 @@ services:
   redis:
     container_name: redis
     image: cgr.dev/chainguard/valkey:latest
-    command: --save 30 1
-    user: 0:0
+    command: --save 60 1
     networks:
       - searxng
     volumes:
-      - redis-data:/data
+      - valkey-data:/data
     cap_drop:
       - ALL
     cap_add:
@@ -76,4 +75,4 @@ networks:
 volumes:
   caddy-data:
   caddy-config:
-  redis-data:
+  valkey-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,12 +10,16 @@ services:
     environment:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost:80}
       - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
     logging:
       driver: json-file
       options:
-        max-size: "5m"
+        max-size: "1m"
         max-file: "1"
 
   searxng:
@@ -29,12 +33,18 @@ services:
       - ./searxng:/etc/searxng:rw
     environment:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
     security_opt:
       - no-new-privileges:true
     logging:
       driver: json-file
       options:
-        max-size: "5m"
+        max-size: "1m"
         max-file: "1"
 
   valkey:
@@ -46,6 +56,12 @@ services:
       - searxng
     volumes:
       - redis-data:/data
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
     security_opt:
       - no-new-privileges:true
     logging:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   caddy:
     container_name: caddy
@@ -7,15 +5,13 @@ services:
     network_mode: host
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy-data:/data:rw
-      - caddy-config:/config:rw
+      - caddy-data:/data
+      - caddy-config:/config
     environment:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost:80}
       - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
-    cap_drop:
-      - ALL
-    cap_add:
-      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
 
   searxng:
     container_name: searxng
@@ -25,20 +21,11 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     volumes:
-      - ./searxng:/etc/searxng:rw
+      - ./searxng:/etc/searxng
     environment:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
-    cap_drop:
-      - ALL
-    cap_add:
-      - CHOWN
-      - SETGID
-      - SETUID
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "1m"
-        max-file: "1"
+    security_opt:
+      - no-new-privileges:true
 
   valkey:
     container_name: valkey
@@ -53,8 +40,6 @@ services:
 
 networks:
   searxng:
-    ipam:
-      driver: default
 
 volumes:
   caddy-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+version: "3.7"
+
 services:
   caddy:
     container_name: caddy
@@ -23,7 +25,7 @@ services:
   redis:
     container_name: redis
     image: cgr.dev/chainguard/valkey:latest
-    command: --save 60 1 --loglevel warning
+    command: --save 30 1 --loglevel warning
     networks:
       - searxng
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,29 @@ services:
         max-size: "1m"
         max-file: "1"
 
+  redis:
+    container_name: redis
+    image: cgr.dev/chainguard/valkey:latest
+    command: --save 30 1
+    user: 0:0
+    networks:
+      - searxng
+    volumes:
+      - redis-data:/data
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "1"
+
   searxng:
     container_name: searxng
     image: docker.io/searxng/searxng:latest
@@ -39,29 +62,6 @@ services:
       - CHOWN
       - SETGID
       - SETUID
-    security_opt:
-      - no-new-privileges:true
-    logging:
-      driver: json-file
-      options:
-        max-size: "1m"
-        max-file: "1"
-
-  valkey:
-    container_name: valkey
-    image: cgr.dev/chainguard/valkey:latest
-    command: --save 30 1
-    user: 0:0
-    networks:
-      - searxng
-    volumes:
-      - redis-data:/data
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETGID
-      - SETUID
-      - DAC_OVERRIDE
     security_opt:
       - no-new-privileges:true
     logging:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,13 +5,18 @@ services:
     network_mode: host
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy-data:/data
-      - caddy-config:/config
+      - caddy-data:/data:rw
+      - caddy-config:/config:rw
     environment:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost:80}
       - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
     security_opt:
       - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "1"
 
   searxng:
     container_name: searxng
@@ -21,11 +26,16 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     volumes:
-      - ./searxng:/etc/searxng
+      - ./searxng:/etc/searxng:rw
     environment:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
     security_opt:
       - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "1"
 
   valkey:
     container_name: valkey
@@ -34,9 +44,14 @@ services:
     networks:
       - searxng
     volumes:
-      - valkey-data:/data
+      - redis-data:/data
     security_opt:
       - no-new-privileges:true
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "1"
 
 networks:
   searxng:
@@ -44,4 +59,4 @@ networks:
 volumes:
   caddy-data:
   caddy-config:
-  valkey-data:
+  redis-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,10 +14,8 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
-    security_opt:
-      - no-new-privileges:true
     logging:
-      driver: json-file
+      driver: "json-file"
       options:
         max-size: "1m"
         max-file: "1"
@@ -25,7 +23,7 @@ services:
   redis:
     container_name: redis
     image: cgr.dev/chainguard/valkey:latest
-    command: --save 60 1
+    command: --save 60 1 --loglevel warning
     networks:
       - searxng
     volumes:
@@ -36,10 +34,8 @@ services:
       - SETGID
       - SETUID
       - DAC_OVERRIDE
-    security_opt:
-      - no-new-privileges:true
     logging:
-      driver: json-file
+      driver: "json-file"
       options:
         max-size: "1m"
         max-file: "1"
@@ -61,10 +57,8 @@ services:
       - CHOWN
       - SETGID
       - SETUID
-    security_opt:
-      - no-new-privileges:true
     logging:
-      driver: json-file
+      driver: "json-file"
       options:
         max-size: "1m"
         max-file: "1"

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -8,4 +8,4 @@ server:
 ui:
   static_use_hash: true
 redis:
-  url: redis://redis:6379/0
+  url: redis://valkey:6379/0

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -8,4 +8,4 @@ server:
 ui:
   static_use_hash: true
 redis:
-  url: redis://valkey:6379/0
+  url: redis://redis:6379/0


### PR DESCRIPTION
You know, licensing changes yada yada yada ([#3348](https://github.com/searxng/searxng/issues/3348)). This PR replaces Redis by Valkey and cleans up some deprecated, useless or non-defined options in the Docker compose spec. I have already bothered to test if SearXNG works correctly with Valkey, and so far it looks good as they want to maintain interoperability with Redis.

EDIT: Also reduce the logging files for caddy and redis.