### PR TITLE
feat: uwsgi workers / threads configuration options

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,10 @@
 
 # SEARXNG_HOSTNAME=<host>
 # LETSENCRYPT_EMAIL=<email>
+
+# Optional:
+# If you run a very small or a very large instance, you might want to change the amount of used uwsgi workers and threads per worker
+# More workers (= processes) means that more search requests can be handled at the same time, but it also causes more resource usage
+
+# SEARXNG_UWSGI_WORKERS=4
+# SEARXNG_UWSGI_THREADS=4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,6 +56,8 @@ services:
       - ./searxng:/etc/searxng:rw
     environment:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
+      - UWSGI_WORKERS=${SEARXNG_UWSGI_WORKERS:-4}
+      - UWSGI_THREADS=${SEARXNG_UWSGI_THREADS:-4}
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
I think that it makes sense to make it obvious for instance hosters that they can configure how many resources they want to allocate to SearXNG. Small instance certainly don't need 4 workers, and large instances probably should use more (if the hardware is decent enough to handle it).

see https://github.com/searxng/searxng/pull/2992 for reference / more information about uwsgi workers and threads