### PR TITLE
Include missing uwsgi.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 searxng-docker.service
 caddy
 srv
-searxng/uwsgi.ini
+# searxng/uwsgi.ini

--- a/searxng/uwsgi.ini
+++ b/searxng/uwsgi.ini
@@ -1,0 +1,49 @@
+[uwsgi]
+# Who will run the code
+uid = searxng
+gid = searxng
+
+# Number of workers (usually CPU count)
+workers = %k
+threads = 4
+
+# The right granted on the created socket
+chmod-socket = 666
+
+# Plugin to use and interpreter config
+single-interpreter = true
+master = true
+plugin = python3
+lazy-apps = true
+enable-threads = 4
+
+# Module to import
+module = searx.webapp
+
+# Virtualenv and python path
+pythonpath = /usr/local/searxng/
+chdir = /usr/local/searxng/searx/
+
+# automatically set processes name to something meaningful
+auto-procname = true
+
+# Disable request logging for privacy
+disable-logging = true
+log-5xx = true
+
+# Set the max size of a request (request-body excluded)
+buffer-size = 8192
+
+# No keep alive
+# See https://github.com/searx/searx-docker/issues/24
+add-header = Connection: close
+
+# uwsgi serves the static files
+# expires set to one year since there are hashes
+static-map = /static=/usr/local/searxng/searx/static
+static-expires = /* 31557600
+static-gzip-all = True
+offload-threads = 4
+
+# Cache
+cache2 = name=searxngcache,items=2000,blocks=2000,blocksize=4096,bitmap=1


### PR DESCRIPTION
There is probably a reason why this file is in the gitignore, and not included in the source tree, but I'm opening this PR to start discussion on proper fix, as the docker compose doesn't work without it.

Possible fixes:
1. Accept this PR and merge
2. Add the file to project's root directory (or elsewhere) and update README that the file should be copied into proper location

This fixes #115