### PR TITLE
Remove Docker Compose V1 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ Create a new SearXNG instance in five minutes using Docker
 - Check everything is working: `docker compose up`
 - Run SearXNG in the background: `docker compose up -d`
 
-> [!WARNING]  
-> If you use an older version of docker desktop (`< 3.6.0`), you may have to install Docker Compose v1.
-> Accordingly, you should modify the commands in this documentation to suit Docker Compose v1. For instance, change 'docker compose up' to 'docker-compose up'.
->
-> [Install the docker-compose plugin](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin) (be sure that docker-compose version is at least 1.9.0)
-
 > [!NOTE]  
 > Windows users can use the following powershell script to generate the secret key:
 > ```powershell
@@ -86,12 +80,4 @@ To update the SearXNG stack:
 git pull
 docker compose pull
 docker compose up -d
-```
-
-Or the old way (with the old docker-compose version):
-
-```sh
-git pull
-docker-compose pull
-docker-compose up -d
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   caddy:
     container_name: caddy


### PR DESCRIPTION
The last version of Compose V1 was released on May 10, 2021 and began to be phased out gradually, as of July 2023 its availability has been completely removed.

More details here: https://docs.docker.com/compose/migrate/