### PR TITLE
Rework Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,7 @@
 	log {
 		output stderr
 		format filter {
-			# Preserves fist 8 bits from IPv4 and 32 bits from IPv6
+			# Preserves first 8 bits from IPv4 and 32 bits from IPv6
 			request>remote_ip ip_mask 8 32
 			request>client_ip ip_mask 8 32
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -67,7 +67,7 @@ header @api {
 route {
 	# Caching
 	header Cache-Control "no-cache, no-store"
-	header @static Cache-Control "max-age=31536000"
+	header @static Cache-Control "public, max-age=31536000"
 
 	# CSP (https://content-security-policy.com)
 	header Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,99 +1,84 @@
 {
-  admin off
+	admin off
+
+	log {
+		output stderr
+		format filter {
+			# Preserves fist 8 bits from IPv4 and 32 bits from IPv6
+			request>remote_ip ip_mask 8 32
+			request>client_ip ip_mask 8 32
+
+			# Remove identificable information
+			request>remote_port delete
+			request>headers delete
+			request>uri query {
+				delete url
+				delete h
+				delete q
+			}
+		}
+	}
 }
 
-{$SEARXNG_HOSTNAME} {
-  log {
-        output discard
-  }
+{$SEARXNG_HOSTNAME:http://localhost}
 
-  tls {$SEARXNG_TLS}
+tls {$SEARXNG_TLS:internal}
 
-  @api {
-        path /config
-        path /healthz
-        path /stats/errors
-        path /stats/checker
-  }
+@api {
+	path /config
+	path /healthz
+	path /stats/errors
+	path /stats/checker
+}
 
-  @static {
-        path /static/*
-  }
+@static {
+	path /static/*
+}
 
-  @notstatic {
-        not path /static/*
-  }
+@imageproxy {
+	path /image_proxy
+}
 
-  @imageproxy {
-        path /image_proxy
-  }
+header {
+	# Force clients to use HTTPS
+	Strict-Transport-Security "max-age=31536000"
 
-  @notimageproxy {
-        not path /image_proxy
-  }
+	# Prevent MIME type sniffing from the declared Content-Type
+	X-Content-Type-Options "nosniff"
 
-  header {
-        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
-        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+	# Disable some browser features
+	Permissions-Policy "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),cross-origin-isolated=(),display-capture=(self),document-domain=(),encrypted-media=(),execution-while-not-rendered=(),execution-while-out-of-viewport=(),fullscreen=(self),geolocation=(),gyroscope=(),keyboard-map=(self),magnetometer=(),microphone=(),midi=(),navigation-override=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(),usb=(),web-share=(),xr-spatial-tracking=()"
 
-        # Enable cross-site filter (XSS) and tell browser to block detected attacks
-        X-XSS-Protection "1; mode=block"
+	# Set referrer policy
+	Referrer-Policy "no-referrer"
 
-        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
-        X-Content-Type-Options "nosniff"
+	# X-Robots-Tag (comment to allow site indexing)
+	X-Robots-Tag "noindex, noarchive, nofollow"
 
-        # Disable some features
-        Permissions-Policy "accelerometer=(),ambient-light-sensor=(),autoplay=(),camera=(),encrypted-media=(),focus-without-user-activation=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),midi=(),payment=(),picture-in-picture=(),speaker=(),sync-xhr=(),usb=(),vr=()"
+	# Remove "Server" header
+	-Server
+}
 
-        # Disable some features (legacy)
-        Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
+header @api {
+	Access-Control-Allow-Methods "GET, OPTIONS"
+	Access-Control-Allow-Origin "*"
+}
 
-        # Referer
-        Referrer-Policy "no-referrer"
+route {
+	# Caching
+	header Cache-Control "no-cache, no-store"
+	header @static Cache-Control "max-age=31536000"
 
-        # X-Robots-Tag
-        X-Robots-Tag "noindex, noarchive, nofollow"
+	# CSP (https://content-security-policy.com)
+	header Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
+	header @imageproxy Content-Security-Policy "default-src 'none'; img-src 'self' data:"
+}
 
-        # Remove Server header
-        -Server
-  }
+# SearXNG (uWSGI)
+reverse_proxy localhost:8080 {
+	header_up X-Forwarded-Port {http.request.port}
+	header_up X-Real-IP {http.request.remote.host}
 
-  header @api {
-        Access-Control-Allow-Methods "GET, OPTIONS"
-        Access-Control-Allow-Origin  "*"
-  }
-
-  # Cache
-  header @static {
-        # Cache
-        Cache-Control "public, max-age=31536000"
-        defer
-  }
-
-  header @notstatic {
-        # No Cache
-        Cache-Control "no-cache, no-store"
-        Pragma "no-cache"
-  }
-
-  # CSP (see http://content-security-policy.com/ )
-  header @imageproxy {
-        Content-Security-Policy "default-src 'none'; img-src 'self' data:"
-  }
-
-  header @notimageproxy {
-        Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
-  }
-
-  # SearXNG
-  handle {
-        encode zstd gzip
-
-        reverse_proxy localhost:8080 {
-               header_up X-Forwarded-Port {http.request.port}
-               header_up X-Forwarded-Proto {http.request.scheme}
-               header_up X-Real-IP {remote_host}
-        }
-  }
-
+	# https://github.com/searx/searx-docker/issues/24
+	header_up Connection "close"
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -33,26 +33,33 @@ encode zstd gzip
 	path /stats/checker
 }
 
-@static {
-	path /static/*
+@search {
+	path /search
 }
 
 @imageproxy {
 	path /image_proxy
 }
 
-header {
-	# Force clients to use HTTPS
-	Strict-Transport-Security "max-age=31536000"
+@static {
+	path /static/*
+}
 
-	# Prevent MIME type sniffing from the declared Content-Type
-	X-Content-Type-Options "nosniff"
+header {
+	# CSP (https://content-security-policy.com)
+	Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src * data:; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com;"
 
 	# Disable some browser features
 	Permissions-Policy "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"
 
 	# Set referrer policy
 	Referrer-Policy "no-referrer"
+
+	# Force clients to use HTTPS
+	Strict-Transport-Security "max-age=31536000"
+
+	# Prevent MIME type sniffing from the declared Content-Type
+	X-Content-Type-Options "nosniff"
 
 	# X-Robots-Tag (comment to allow site indexing)
 	X-Robots-Tag "noindex, noarchive, nofollow"
@@ -67,13 +74,11 @@ header @api {
 }
 
 route {
-	# Caching
-	header Cache-Control "no-cache, no-store"
-	header @static Cache-Control "public, max-age=31536000"
-
-	# CSP (https://content-security-policy.com)
-	header Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
-	header @imageproxy Content-Security-Policy "default-src 'none'; img-src 'self' data:"
+	# Cache policy
+	header Cache-Control "max-age=0, no-store"
+	header @search Cache-Control "max-age=5, private"
+	header @imageproxy Cache-Control "max-age=604800, public"
+	header @static Cache-Control "max-age=31536000, public, immutable"
 }
 
 # SearXNG (uWSGI)

--- a/Caddyfile
+++ b/Caddyfile
@@ -24,6 +24,8 @@
 
 tls {$SEARXNG_TLS:internal}
 
+encode zstd gzip
+
 @api {
 	path /config
 	path /healthz

--- a/Caddyfile
+++ b/Caddyfile
@@ -47,7 +47,7 @@ header {
 	X-Content-Type-Options "nosniff"
 
 	# Disable some browser features
-	Permissions-Policy "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),cross-origin-isolated=(),display-capture=(self),document-domain=(),encrypted-media=(),execution-while-not-rendered=(),execution-while-out-of-viewport=(),fullscreen=(self),geolocation=(),gyroscope=(),keyboard-map=(self),magnetometer=(),microphone=(),midi=(),navigation-override=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(),usb=(),web-share=(),xr-spatial-tracking=()"
+	Permissions-Policy "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"
 
 	# Set referrer policy
 	Referrer-Policy "no-referrer"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,7 @@ services:
       - caddy-data:/data:rw
       - caddy-config:/config:rw
     environment:
-      - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost:80}
-      - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
+      - SEARXNG_TLS=${LETSENCRYPT_EMAIL}
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
This PR completely reworks the Caddy config file to solve several inconveniences that are not worth having them in separate PRs, the changes are these...

* *Try* to protect the user data *(query searches, IPs and headers)* logged on Caddy if there is an error with the upstream response (or Caddy itself).
* Overwrite the `Cache-Control` header if its matcher token *matches* rather than doing the comparison twice in a row.
* Prefer to set the ENV defaults directly in the Caddyfile.
* Modified the `Strict-Transport-Security` header to not include **all** subdomains in the HSTS policy nor mark the latter to enter the HSTS preload list.
* Modified the `Permissions-Policy` header to [remove useless features](https://github.com/searxng/searxng-docker/pull/255/commits/5d066a4c63e102d4966e7baccc1072ffae732fa7).
* Remove the `X-XSS-Protection` and `Feature-Policy` headers following the standards recommendations and evaluating the possible impact with older clients.
* Other minor structure and format changes.

All changes have been tested and validated without requiring major changes for users.