### PR TITLE
Fix "missing files"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
       - CHOWN
       - SETGID
       - SETUID
+      - DAC_OVERRIDE
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
The container only runs without permissions at the moment it runs the uWSGI server, the rest of the script runs with the ownership that Docker is running (by default root unless overriden with "[user](https://docs.docker.com/reference/compose-file/services/#user)" directive) so other container managers such as Podman or Docker rootless are *(should)* not affected by this issue. See [this](https://docs.docker.com/engine/security/#linux-kernel-capabilities).

Before you go and copypaste this into your compose file, you **must** know that this solution is **UNSAFE** and you will give the container **FULL ACCESS** to your host **FILESYSTEM**. *Also this does not work for systems that actively enforce a SELinux policy.* By setting the `DAC_OVERRIDE` flag you are giving the privilege to completely override permissions allowing you to modify other files on the host such as the mounted *searxng/* folder, doing this will give new files the root ownership:

![Screenshot](https://github.com/user-attachments/assets/e1eb8edc-e4a2-4e55-898f-c66a934fb788)

The good and *not so flexible* solution is to set with "[user](https://docs.docker.com/reference/compose-file/services/#user)" directive in your compose file with the UID/GID of the ownership where that folder is located, avoiding the use of that devil's flag and continue to use SELinux without adding new policies:

![Screenshot](https://github.com/user-attachments/assets/ee4046b6-586b-4fa2-b767-fc372047437a)

As this solution requires additional config *(besides not being possible in some cases)* it is omitted as a default solution, at most a note about this could be added on README.

Closes #238 #252 #258
Related #115