### PR TITLE
Remove depricated version element

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   caddy:
     container_name: caddy


### PR DESCRIPTION
As described at https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements the "version" element within docker-compose files has been purely informative for a long time and now gives a warning every time the stack is brought up. It may therefore make sense to remove it from the official docker-compose.yaml.