### PR TITLE
Revert env fallback on Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -20,9 +20,9 @@
 	}
 }
 
-{$SEARXNG_HOSTNAME:http://localhost}
+{$SEARXNG_HOSTNAME}
 
-tls {$SEARXNG_TLS:internal}
+tls {$SEARXNG_TLS}
 
 encode zstd gzip
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,8 @@ services:
       - caddy-data:/data:rw
       - caddy-config:/config:rw
     environment:
-      - SEARXNG_TLS=${LETSENCRYPT_EMAIL}
+      - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost}
+      - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
     cap_drop:
       - ALL
     cap_add:


### PR DESCRIPTION
It seems that an empty string was being returned with SEARXNG_TLS when LETSENCRYPT_EMAIL was not defined. As there is no way to fix this without restructuring how compose handles the env to each container, I am reverting this whole part.

Closes #337 