### PR TITLE
use Docker init instead of tini

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
     container_name: searxng
     image: docker.io/searxng/searxng:latest
     restart: unless-stopped
+    init: true
     networks:
       - searxng
     ports:


### PR DESCRIPTION
use https://docs.docker.com/reference/cli/docker/container/run/#init instead of tini.

PR to synchronise with https://github.com/searxng/searxng/pull/4463