### PR TITLE
chore: deactivate limiter by default for easier setup

### DIFF
--- a/searxng/limiter.toml
+++ b/searxng/limiter.toml
@@ -2,5 +2,6 @@
 # See https://github.com/searxng/searxng/blob/master/searx/limiter.toml
 
 [botdetection.ip_limit]
-# activate link_token method in the ip_limit method
-link_token = true
+# activate advanced bot protection
+# enable this when running the instance for a public usage on the internet
+link_token = false

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -3,7 +3,7 @@ use_default_settings: true
 server:
   # base_url is defined in the SEARXNG_BASE_URL environment variable, see .env and docker-compose.yml
   secret_key: "ultrasecretkey"  # change this!
-  limiter: true  # can be disabled for a private instance
+  limiter: false  # enable this when running the instance for a public usage on the internet
   image_proxy: true
 ui:
   static_use_hash: true


### PR DESCRIPTION
Deactivate the limiter and advanced bot protection to make it easier to deploy a private SearXNG instance.

- Beginners wanting to host SearXNG for use in their program won't have issues with the bot protection anymore.
- Weird setups won't pose an issue anymore, as the limiter won't force into having the correct headers for IP forwarding.
- The bot protection and limiter are only needed for public instances. And public instances are already forced to have the bot protection and limiter activated: https://github.com/searxng/searxng/blob/064eb504733c250d2e43b6db8ac37812ad18d2fa/searx/limiter.py#L235-L251

I'll still do my best to alert the community of this change, but I do not expect this to pause any issue. Instead, I expect questions/issues like these to become less common:

![image](https://github.com/user-attachments/assets/8d3aa0e0-4923-4193-bff7-f9efa59c900d)

![image](https://github.com/user-attachments/assets/ed25f15f-4c0a-424a-9fb7-caed446cbe00)

Actually caused by having the bot protection on and some missing configuration that is only suited for public instances.