### PR TITLE
chore: Add back security cap

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,10 @@ services:
     environment:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-http://localhost}
       - SEARXNG_TLS=${LETSENCRYPT_EMAIL:-internal}
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     logging:
       driver: "json-file"
       options:
@@ -28,6 +32,12 @@ services:
       - searxng
     volumes:
       - valkey-data2:/data
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
     logging:
       driver: "json-file"
       options:
@@ -48,6 +58,12 @@ services:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
       - UWSGI_WORKERS=${SEARXNG_UWSGI_WORKERS:-4}
       - UWSGI_THREADS=${SEARXNG_UWSGI_THREADS:-4}
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
This reverts commit 31acd45ec22a5702a15b5e67d6fa725e92eadb83.

There won't be any need to deactivate security cap due to permissions issues.

Pending resolution on:
- [ ] https://github.com/searxng/searxng/issues/4818
- [ ] https://github.com/searxng/searxng/pull/4820