### PR TITLE
[fix] caddy: revise csp header

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -56,7 +56,7 @@ encode zstd gzip
 
 header {
 	# CSP (https://content-security-policy.com)
-	Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https://github.com/searxng/searxng/issues/new; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src * data:; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com;"
+	Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https:; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self'; img-src * data:; frame-src https:;"
 
 	# Disable some browser features
 	Permissions-Policy "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"


### PR DESCRIPTION
Relaxes some policies, there are obsolete options that are not currently in use that have been removed as well.

Closes https://github.com/searxng/searxng-docker/issues/371
Closes https://github.com/searxng/searxng-docker/issues/177
Closes https://github.com/searxng/searxng/issues/4304