### PR TITLE
Update Caddyfile - enable HSTS

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -65,6 +65,9 @@ header {
 
 	# Comment header to allow indexing by search engines
 	X-Robots-Tag "noindex, nofollow, noarchive, nositelinkssearchbox, nosnippet, notranslate, noimageindex"
+    
+	# enable HSTS
+	Strict-Transport-Security max-age=15768000;
 
 	# Remove "Server" header
 	-Server

--- a/Caddyfile
+++ b/Caddyfile
@@ -67,7 +67,9 @@ header {
 	X-Robots-Tag "noindex, nofollow, noarchive, nositelinkssearchbox, nosnippet, notranslate, noimageindex"
     
 	# enable HSTS
-	Strict-Transport-Security max-age=15768000;
+	# WARNING: Once this value is set, the site must continue to support HTTPS until the expiry time is reached.
+
+	# Strict-Transport-Security max-age=15768000;
 
 	# Remove "Server" header
 	-Server


### PR DESCRIPTION
HSTS is required to achieve a good score in the Mozilla Observatory test (https://developer.mozilla.org/en-US/observatory/analyze), which is one of the criteria on the https://searx.space instance list.
Caddyfile has been updated to enable the HTTP Strict Transport Security, with six months cache.

Best regards,
Maciej Błędkowski