### PR TITLE
[mod] caddy: update csp

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -52,7 +52,7 @@ encode zstd gzip
 
 header {
 	# CSP (https://content-security-policy.com)
-	Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self' https:; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self'; img-src * data:; frame-src https:;"
+	Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; form-action 'self' https:; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self'; img-src * data:; frame-src https:;"
 
 	# Disable browser features
 	Permissions-Policy "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()"


### PR DESCRIPTION
Since https://github.com/searxng/searxng/pull/5073 we add a script directly to the [`base.html`](https://github.com/searxng/searxng/blob/master/searx/templates/simple/base.html), we need `'unsafe-inline'`.