### PR TITLE
Removed the "version" attribute in response to issue #427

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   caddy:
     container_name: caddy


### PR DESCRIPTION
I had the same issue. According to the Docker [website](https://docs.docker.com/reference/compose-file/version-and-name/), the attribute is obsolete. I removed the attribute, the message no longer appears in the container logs.